### PR TITLE
move output.raw to client folder

### DIFF
--- a/converttoraw.py
+++ b/converttoraw.py
@@ -2,7 +2,7 @@ import os
 from PIL import Image
 
 input_directory = "campfire/rec"
-output_file = "output.raw"
+output_file = "client/output.raw"
 
 def convert_tif_stack_to_raw(input_directory, output_file):
     # Get the list of TIF files in the input directory


### PR DESCRIPTION
Hi, Luke

Thanks for this cool project. I will definitely want to explore more on the tool you make.

Here's a small step that I think can make the process smoother for the person who use it at the first time like me. When I follow 5. in Usage Instructions to start the server, I found I can't see anything because output.raw is not put in the right place. It confused me for a while. So I think it would be better to move output.raw to the client folder directly. What do you think? If you don't think it's suitable, feel free to close this PR directly, thanks!