### PR TITLE
Correct grammar, add/update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Scroll Viewer
 
-Please note: Active devleopment is ongoing on the dev branch, look there if you want to read through code
+Please note: Active development is ongoing on the [dev branch](https://github.com/lukeboi/scroll-viewer/tree/dev), look there if you want to read through the code.
 
 ![screenshot](./cover.png)
 
-This is a web-based volumetric renderer for use in the [Vesuvius Challenge](https://scrollprize.org/). Currently supports viewing the campfire scroll with fast, webgl-based rendering, color themes, and layer isolation features. 
+This is a web-based volumetric renderer for use in the [Vesuvius Challenge](https://scrollprize.org/). Currently supports viewing the campfire scroll with fast, webgl-based rendering, color themes, and layer isolation features.
 
 Contributions are most welcome! Some future plans for the project:
-- View larger scrolls (ie the fragments) via progressive loading and level of detail
+- View larger scrolls (i.e. the fragments) via progressive loading and level of detail
 - View ground-truth segmentations
 - Annotate scroll layers and virtually unwrap (this can be done in-browser via webgl magic)
 - Integrate with your custom ink detection backends
@@ -19,6 +19,6 @@ Contributions are most welcome! Some future plans for the project:
 3. Unzip campfire.zip and place it in the home directory of this repository
 4. Run the conversion script with `python converttoraw.py`. This converts the campfire scroll data into an 8-bit 3d texture file, which can be loaded into the scroll viewer. You may need to adjust the `input_directory` variable of the script.
 5. Run the scroll viewer with any http server. I recommend `python -m http.server 8000` from the client folder, which can be accessed at `localhost:8000` in your web browser.
-6. If you have any issues at all, please don't hesistate to open an issue ticket, reach out on the [Vesuvius Challenge Discord](https://discord.gg/6FgWYNjb4N) or contact me [on twitter](https://twitter.com/LukeFarritor). I'm here to help!
+6. If you have any issues at all, please don't hesistate to open an [issue ticket](https://github.com/lukeboi/scroll-viewer/issues), reach out on the [Vesuvius Challenge Discord](https://discord.gg/V4fJhvtaQn) or contact me [on twitter](https://twitter.com/LukeFarritor). I'm here to help!
 
-Volumetric rendering is well-explored problem with countless implementations on the internet. I'm using [webgl-volume-raycaster](https://github.com/Twinklebear/webgl-volume-raycaster) as a boilerplate. That repo includes [a great tutorial](https://www.willusher.io/webgl/2019/01/13/volume-rendering-with-webgl) on the basics of volumetric rendering which I highly recommend to all who want to learn more.
+Volumetric rendering is a well-explored problem with countless implementations on the internet. I'm using [webgl-volume-raycaster](https://github.com/Twinklebear/webgl-volume-raycaster) as a boilerplate. That repo includes [a great tutorial](https://www.willusher.io/webgl/2019/01/13/volume-rendering-with-webgl) on the basics of volumetric rendering which I highly recommend to all who want to learn more.


### PR DESCRIPTION
Corrects grammar, adds internal GitHub links and updates the Vesuvius Challenge Discord invite URL.
(which was previously also inconsistent on the Scrollprize website, this has since been corrected.)

(internal GitHub links may use [relative links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links) instead.)